### PR TITLE
fix "Hyde-istall" typo

### DIFF
--- a/Hyde-install
+++ b/Hyde-install
@@ -135,4 +135,4 @@ export GIT
 
 export CloneDir=${newCloneDir}
 
-if ! main; then print_prompt -crit "[error] " "Hyde-istall Terminated"; fi
+if ! main; then print_prompt -crit "[error] " "Hyde-install Terminated"; fi


### PR DESCRIPTION
someone on discord pointed out that when it fails it says hyde-istall instead of hyde-install